### PR TITLE
Add librtmp.so.1 into library_paths

### DIFF
--- a/librtmp_config/__init__.py
+++ b/librtmp_config/__init__.py
@@ -12,4 +12,4 @@ __all__ = ["library_paths"]
 
 #: This is a list of filenames that python-librtmp
 #: will attempt to dynamically load `librtmp` from.
-library_paths = ["librtmp.so", "librtmp.so.0", "librtmp.dll"]
+library_paths = ["librtmp.so", "librtmp.so.0", "librtmp.dll", "librtmp.so.1"]


### PR DESCRIPTION
Since rtmpdump commit `a9f353c Bump the SO_VERSION to 1` linux produces librtmp.so.1 library name.
