### PR TITLE
Add librtmp.dylib into library_paths

### DIFF
--- a/librtmp_config/__init__.py
+++ b/librtmp_config/__init__.py
@@ -12,4 +12,4 @@ __all__ = ["library_paths"]
 
 #: This is a list of filenames that python-librtmp
 #: will attempt to dynamically load `librtmp` from.
-library_paths = ["librtmp.so", "librtmp.so.0", "librtmp.dll", "librtmp.so.1"]
+library_paths = ["librtmp.so", "librtmp.so.0", "librtmp.dll", "librtmp.so.1", "librtmp.dylib"]


### PR DESCRIPTION
librtmp is compiled to librtmp.dylib on OSX, so this will allow python-librtmp to find the library on Mac.
